### PR TITLE
fix(ci): allow Dependabot PRs to enable auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
 permissions:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   automerge:
-    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'security') }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'security') }}
     runs-on: ubuntu-latest
     steps:
       - run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
### Motivation
- Dependabot-opened PRs running on the `pull_request` event receive a restricted token which prevents `gh pr merge --auto` from enabling auto-merge. 
- The job actor can vary for events like `labeled`, so the check should target the PR author to reliably detect Dependabot-created PRs.

### Description
- Changed the workflow trigger from `pull_request` to `pull_request_target` in `.github/workflows/dependabot-auto-merge.yml` so the job runs with a token capable of `pull-requests: write` actions. 
- Replaced the job condition from `github.actor == 'dependabot[bot]'` to `github.event.pull_request.user.login == 'dependabot[bot]'` to ensure the workflow targets PRs opened by Dependabot. 

### Testing
- Verified repository files and workflow presence with `rg --files .github && rg -n "dependabot|automerge|auto-merge|pull_request|pull-request|workflow" .github`, which succeeded. 
- Inspected workflow and dependabot config with `sed -n '1,220p' .github/workflows/dependabot-auto-merge.yml && echo '---' && sed -n '1,220p' .github/dependabot.yml`, which succeeded. 
- Confirmed the diff and committed the change using `git diff -- .github/workflows/dependabot-auto-merge.yml` and `git commit -m "fix(ci): enable dependabot automerge workflow permissions"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebfe4e370832e95c3b99bc87a3438)